### PR TITLE
add odos routerV2

### DIFF
--- a/data/manual/spenders/324/0x4bBa932E9792A2b917D47830C93a9BC79320E4f7.json
+++ b/data/manual/spenders/324/0x4bBa932E9792A2b917D47830C93a9BC79320E4f7.json
@@ -1,0 +1,4 @@
+{
+  "name": "Odos",
+  "label": "Odos: RouterV2"
+}


### PR DESCRIPTION
zkSwap ZAP uses Odos Router V2 for liquidity routing, so we add this contract